### PR TITLE
Survivor Encounters

### DIFF
--- a/the-wanderers/scripts/game.js
+++ b/the-wanderers/scripts/game.js
@@ -92,7 +92,10 @@ export function playTurn() {
                 checkPosTraitEvents(character);
                 checkNegTraitEvents(character);
                 checkAgeEffects(character);
-                checkBirthday(character);
+                // Only check birthdays during the day
+                if (context.timeOfDay === 'day') {
+                    checkBirthday(character);
+                }
                 // Make sure attributes are within bounds
                 character.capAttributes();
                 updateStatBars(character);

--- a/the-wanderers/scripts/game.js
+++ b/the-wanderers/scripts/game.js
@@ -166,10 +166,16 @@ export function playTurn() {
                     updateRelationships();
                 }
             } else {
-                addEvent(`${character.name} died of hunger.`);
-                handleDeathEffects(character);
-                context.gameParty.removeCharacter(character);
-                updateRelationships();
+                // Satiated characters cannot die from hunger - they survive at 0
+                if (character.posTrait === 'satiated') {
+                    character.hunger = 0;
+                    addEvent(`${character.name} is starving but manages to hold on.`);
+                } else {
+                    addEvent(`${character.name} died of hunger.`);
+                    handleDeathEffects(character);
+                    context.gameParty.removeCharacter(character);
+                    updateRelationships();
+                }
             }
             checkPartyAlerts(character);
         };

--- a/the-wanderers/scripts/party.js
+++ b/the-wanderers/scripts/party.js
@@ -8,6 +8,11 @@ export const food = [
         'some fruit mix',
         'a box of biscuits',
         'a packet of oatmeal'
+    ], [
+        'in a child\'s lunch box outside an old school',
+        'tucked inside a torn military jacket',
+        'stashed on the bottom row of a broken vending machine',
+        'hidden under the floorboards of a small barricaded cabin'
     ]],
     ['snack', 1, [
         'an apple',
@@ -17,6 +22,11 @@ export const food = [
         'a jar of pickles',
         'a can of fish',
         'a pickled egg'
+    ], [
+        'in the back of the pantry of a ruined house',
+        'under a pile of smashed dishes on the floor of a kitchen',
+        'inside a backpack hidden in the bushes',
+        'in the clutches of a decayed corpse'
     ]],
     ['dish', 2, [
         'a can of soup',
@@ -26,6 +36,10 @@ export const food = [
         'a frozen pie',
         'a bowl of pasta',
         'a can of stew'
+    ], [
+        'inside a toppled over microwave',
+        'sitting on a rusted stovetop',
+        'stuffed beside old batteries in a kitchen drawer'
     ]],
     ['meal', 3, [
         'a frozen roast chicken',
@@ -35,6 +49,10 @@ export const food = [
         'a frozen tv dinner',
         'some mystery pasta',
         'a really big block of cheese'
+    ], [
+        'buried under rubble at the bottom of a grocery store freezer',
+        'in a backpack beside a burned out fire pit',
+        'somehow stuffed into a small mailbox'
     ]],
     ['dessert', 2, [ // dessert is a treat, so it's also beneficial for morale
         'a tub of ice cream',
@@ -43,14 +61,34 @@ export const food = [
         'a packet of marshmallows',
         'a can of whipped cream',
         'a tin of pudding'
+    ], [
+        'inside a barely functioning minifridge',
+        'nearly crushed under a collapsed bunk bed',
+        'stuffed in the kitchen of a doll house'
     ]]
 ];
 
 export const medical = [
-    ['band aid', 1],
-    ['bandage', 2],
-    ['medicine', 3],
-    ['first aid kit', 4]
+    ['band aid', 1, [
+        'in a child\'s backpack',
+        'stuck to the inside of a locker',
+        'inside a cracked first aid box'
+    ]],
+    ['bandage', 2, [
+        'in the bathroom of an abandoned house',
+        'in the backpack of a dead zombie',
+        'buried under some rubble'
+    ]],
+    ['medicine', 3, [
+        'left on the floor of an abandoned clinic',
+        'in a wrecked ambulance',
+        'hidden in a bathroom cabinet'
+    ]],
+    ['first aid kit', 4, [
+        'in a worn first aid kit',
+        'under some floorboards',
+        'inside a damaged vending machine'
+    ]]
 ];
 
 export const weapons = [

--- a/the-wanderers/scripts/src/character-creation.js
+++ b/the-wanderers/scripts/src/character-creation.js
@@ -5,7 +5,7 @@ import Party, { food, medical, weapons } from '../party.js';
 import { setGameParty } from '../game-state.js';
 import { updateStatBars, addEvent, setPlayButton, updateFoodButtons, updateMedicalButtons, updateInteractionButtons } from './ui.js';
 import { playTurn } from '../game.js';
-import { newCharacterFlavor } from './events.js';
+import { newCharacterFlavour } from './events.js';
 import { addItemToInventory, updateWeaponButtons } from './inventory.js';
 import { resetSeasonalEvents } from './seasonal-events.js';
 
@@ -584,8 +584,8 @@ export function foundFriend() {
     setPlayButton('hide');
     
     const friendDiv = document.createElement('div');
-    const flavorText = newCharacterFlavor[Math.floor(Math.random() * newCharacterFlavor.length)];
-    friendDiv.textContent = `You are approached by an adventurer who wants to join your party. ${flavorText}`;
+    const flavourText = newCharacterFlavour[Math.floor(Math.random() * newCharacterFlavour.length)];
+    friendDiv.textContent = `You are approached by an adventurer who wants to join your party. ${flavourText}`;
     const acceptButton = document.createElement('button');
     acceptButton.textContent = 'Accept';
     acceptButton.addEventListener('click', async () => {

--- a/the-wanderers/scripts/src/combat.js
+++ b/the-wanderers/scripts/src/combat.js
@@ -75,6 +75,7 @@ function handlePlayerTurn(current, combatants, players, context, setPlayButton, 
                         playerCharacter.weaponDurability = weapons[0][2];
                         current.attack = weapons[0][1];
                     }
+                    updateStatBars(playerCharacter);
                 }
                 
                 if (target.hp <= 0) {

--- a/the-wanderers/scripts/src/combat.js
+++ b/the-wanderers/scripts/src/combat.js
@@ -36,6 +36,17 @@ function handlePlayerTurn(current, combatants, players, context, setPlayButton, 
             
             if (roll < 0.1) { // 10% chance to miss
                 addEvent(`${current.type} misses the zombie!`);
+            } else if (playerCharacter.negTrait === 'clumsy' && roll < 0.2) {
+                // Clumsy characters have 10% chance to hurt themselves
+                playerCharacter.health -= 1;
+                addEvent(`${current.type} swings wildly and hurts themself!`);
+                updateStatBars(playerCharacter);
+                if (playerCharacter.health <= 0) {
+                    playerCharacter.health = 0;
+                    addEvent(`${playerCharacter.name} has been knocked out by their own clumsiness!`);
+                    handleDeathEffects(playerCharacter);
+                    context.gameParty.removeCharacter(playerCharacter);
+                }
             } else {
                 if (roll > 0.9) { // 10% chance for critical hit
                     damage *= 2;
@@ -49,7 +60,15 @@ function handlePlayerTurn(current, combatants, players, context, setPlayButton, 
                 
                 // Update weapon durability
                 if (playerCharacter.weapon > 0) {  // If not using fists
-                    playerCharacter.weaponDurability--;
+                    // Fighter: 50% chance to preserve durability
+                    // Clumsy: Uses 2 durability instead of 1
+                    let durabilityLoss = 1;
+                    if (playerCharacter.posTrait === 'fighter' && Math.random() < 0.5) {
+                        durabilityLoss = 0;
+                    } else if (playerCharacter.negTrait === 'clumsy') {
+                        durabilityLoss = 2;
+                    }
+                    playerCharacter.weaponDurability -= durabilityLoss;
                     if (playerCharacter.weaponDurability <= 0) {
                         addEvent(`${playerCharacter.name}'s ${weapons[playerCharacter.weapon][0]} breaks!`);
                         playerCharacter.weapon = 0;  // Back to fists

--- a/the-wanderers/scripts/src/constants.js
+++ b/the-wanderers/scripts/src/constants.js
@@ -1,19 +1,19 @@
 export const posTraits = [
     ['resilient', 'Every turn has a 10% chance to heal', 'Has a higher chance of being cured of illness and infection'],
-    ['satiated', 'Every other turn, hunger does not go down', 'Food items are more effective by 0.5 points'],
-    ['friendly', 'Starts with higher relationships with other party members', 'Can never become cold with other party members'],
+    ['satiated', 'Cannot die from hunger - survives at 0', 'Food items are more effective by 0.5 points'],
+    ['friendly', 'Starts with higher relationships with other party members', 'Higher chance of positive interactions'],
     ['scavenger', 'Every turn has a 10% chance to gain a random food item', 'Gets a food item from every zombie killed'],
-    ['optimistic', 'Every turn has a 10% chance to raise morale', 'Morale cannot fall below bad'],
-    ['fighter', 'Does an extra 1 damage for each attack', 'Has a 50% chance to damage two zombies at once']
+    ['optimistic', 'Lower chance of negative interactions', 'Morale cannot fall below bad'],
+    ['fighter', 'Does an extra 1 damage for each attack', '50% chance to preserve weapon durability']
 ];
 
 export const negTraits = [
     ['vulnerable', 'Takes an extra 1 damage from each attack', 'Has a lower chance of curing illness and infection'],
     ['hungry', 'Every other turn, extra hunger is depleted', 'Rations and snack have no effect'],
-    ['disconnected', 'Starts with lower relationships with other party members', 'Can never become family with other party members'],
-    ['hypochondriac', 'Every turn has a 10% chance to use a medical item without benefit', 'Every turn has a 10% chance to display symptoms of illness despite not being sick'],
-    ['depressed', 'Every turn has a 10% chance to lower morale', 'Morale cannot rise above good'],
-    ['clumsy', 'Every turn has a 10% chance to get hurt', 'Does 1 less damage for each attack']
+    ['disconnected', 'Starts with lower relationships with other party members', 'Higher chance of negative interactions'],
+    ['hypochondriac', 'Every turn has a 10% chance to use a medical item without benefit', '20% chance to steal medical items meant for others'],
+    ['depressed', 'Lower chance of positive interactions', 'Morale cannot rise above good'],
+    ['clumsy', '10% chance to hurt self when attacking', 'Uses double weapon durability']
 ];
 
 export const relationships = [

--- a/the-wanderers/scripts/src/constants.js
+++ b/the-wanderers/scripts/src/constants.js
@@ -25,13 +25,30 @@ export const relationships = [
 ];
 
 export const attackDescriptions = {
-    normal: [
-        '[attacker] whacks a zombie in the head',
-        '[attacker] swings wildly at a zombie',
-        '[attacker] knocks a zombie back',
-        '[attacker] digs their weapon into a zombie',
-        '[attacker] slashes at a zombie',
-        '[attacker] fires a shot at a zombie'
+    // Weapon-specific attack descriptions
+    fist: [
+        '[attacker] throws a punch at a zombie.',
+        '[attacker] swings wildly at a zombie.',
+        '[attacker] lands a solid hit on a zombie.',
+        '[attacker] shoves a zombie back.'
+    ],
+    stick: [
+        '[attacker] whacks a zombie in the head.',
+        '[attacker] swings wildly at a zombie.',
+        '[attacker] knocks a zombie back.',
+        '[attacker] cracks a zombie across the skull.'
+    ],
+    knife: [
+        '[attacker] slashes at a zombie.',
+        '[attacker] stabs at a zombie.',
+        '[attacker] digs their knife into a zombie.',
+        '[attacker] drives the blade into a zombie.'
+    ],
+    pistol: [
+        '[attacker] fires a shot at a zombie.',
+        '[attacker] takes aim and shoots a zombie.',
+        '[attacker] squeezes off a round at a zombie.',
+        '[attacker] puts a bullet in a zombie.'
     ],
     critical: [
         '[attacker] lands a devastating blow!',
@@ -41,12 +58,102 @@ export const attackDescriptions = {
 };
 
 export const zombieAttackDescriptions = [
-    'claws at [NAME]\'s arm',
-    'bites into [NAME]\'s shoulder',
-    'swipes its hand across [NAME]\'s face',
-    'lunges at [NAME]',
-    'grabs at [NAME]\'s leg',
-    'slams its head into [NAME]',
-    'scratches at [NAME]\'s chest',
-    'shoves [NAME] over'
+    'claws at [NAME]\'s arm.',
+    'bites into [NAME]\'s shoulder.',
+    'swipes its hand across [NAME]\'s face.',
+    'lunges at [NAME].',
+    'grabs at [NAME]\'s leg.',
+    'slams its head into [NAME].',
+    'scratches at [NAME]\'s chest.',
+    'shoves [NAME] over.'
+];
+
+// Survivor encounter constants
+export const survivorAttackDescriptions = {
+    // Weapon-specific attack descriptions for survivors
+    fist: [
+        '[attacker] throws a punch at the survivor.',
+        '[attacker] swings wildly at the survivor.',
+        '[attacker] lands a solid hit on the survivor.',
+        '[attacker] shoves the survivor back.'
+    ],
+    stick: [
+        '[attacker] whacks the survivor in the head.',
+        '[attacker] swings their stick at the survivor.',
+        '[attacker] knocks the survivor back.',
+        '[attacker] cracks the survivor across the skull.'
+    ],
+    knife: [
+        '[attacker] slashes at the survivor.',
+        '[attacker] stabs at the survivor.',
+        '[attacker] digs their knife into the survivor.',
+        '[attacker] drives the blade into the survivor.'
+    ],
+    pistol: [
+        '[attacker] fires a shot at the survivor.',
+        '[attacker] takes aim and shoots at the survivor.',
+        '[attacker] squeezes off a round at the survivor.',
+        '[attacker] puts a bullet in the survivor.'
+    ],
+    critical: [
+        '[attacker] lands a devastating blow on the survivor!',
+        '[attacker] finds an opening!',
+        '[attacker] strikes true!'
+    ]
+};
+
+export const hostileSurvivorAttackDescriptions = [
+    'swings a weapon at [NAME].',
+    'lunges at [NAME] with a makeshift club.',
+    'throws a punch at [NAME].',
+    'kicks at [NAME].',
+    'slashes at [NAME] with a blade.',
+    'shoves [NAME] hard.'
+];
+
+export const merchantIntroductions = [
+    'A lone survivor emerges from behind a ruined building',
+    'A wandering trader approaches your camp',
+    'A scavenger waves you down from across the street',
+    'An old survivor with a heavy pack calls out to you',
+    'A nervous-looking trader shuffles toward you'
+];
+
+export const personInNeedIntroductions = [
+    'A desperate survivor stumbles toward your camp',
+    'A wounded stranger calls out for help',
+    'A starving survivor approaches, barely able to stand',
+    'A frightened survivor emerges from hiding',
+    'A survivor with hollow eyes begs for assistance'
+];
+
+export const hostileSurvivorIntroductions = {
+    solo: [
+        'A hostile survivor ambushes you!',
+        'A raider emerges from the shadows!',
+        'A desperate survivor attacks without warning!',
+        'A bandit blocks your path!',
+        'A hostile scavenger attacks!'
+    ],
+    group: [
+        'A group of hostile survivors ambush your camp!',
+        'Raiders emerge from the shadows!',
+        'Desperate survivors attack without warning!',
+        'Bandits surround your party!',
+        'A gang of hostile scavengers attacks!'
+    ]
+};
+
+export const survivorFleeMessages = [
+    'The survivor panics and runs away!',
+    'The trader flees into the ruins!',
+    'The merchant escapes before you can act!',
+    'The survivor disappears into the shadows!'
+];
+
+export const survivorGiveUpMessages = [
+    'The frightened survivor drops the item and runs!',
+    'The trader surrenders the item without a fight!',
+    'The merchant hands over the goods, trembling!',
+    'The survivor throws the item at you and flees!'
 ];

--- a/the-wanderers/scripts/src/events.js
+++ b/the-wanderers/scripts/src/events.js
@@ -4,6 +4,7 @@ import { addItemToInventory, updateWeaponButtons } from './inventory.js';
 import { context } from '../game-state.js';
 import { foundEnemy } from './combat.js';
 import { foundFriend } from './character-creation.js';
+import { foundSurvivor } from './survivor-encounters.js';
 
 export const singleZombieVariations = [
     'ambushes the camp from the bushes',
@@ -198,7 +199,12 @@ export function getEvent(chance) {
         foundFriend();
         specialEventOccurred = true;
     } else if (chance > friendChance && chance <= enemyChance) {
-        foundEnemy(context);
+        // 20% chance of survivor encounter, 80% zombie encounter
+        if (Math.random() < 0.2) {
+            foundSurvivor();
+        } else {
+            foundEnemy(context);
+        }
         specialEventOccurred = true;
     } else if (chance > enemyChance && chance <= secondItem) {
         let items = 1;

--- a/the-wanderers/scripts/src/events.js
+++ b/the-wanderers/scripts/src/events.js
@@ -19,7 +19,7 @@ export const multiZombieVariations = [
     'shamble down the road towards you'
 ];
 
-export const newCharacterFlavor = [
+export const newCharacterFlavour = [
     'They tell you they haven\'t found any shelter for days.',
     'They breathlessly explain that their previous camp was destroyed by zombies.',
     'They tell you they can help you.',
@@ -34,20 +34,9 @@ export const newCharacterFlavor = [
     'They call you an unfamiliar name and seem disappointed when you correct them.'
 ];
 
-export const medicalLocationFlavor = [
-    'in the bathroom of an abandoned house',
-    'in the backpack of a dead zombie',
-    'in a worn first aid kit',
-    'in a wrecked ambulance',
-    'under some floorboards',
-    'left on the floor of an abandoned clinic',
-    'buried under some rubble',
-    'inside a damaged vending machine'
-];
-
 export function foundMedical(who) {
     const medicalType = medical[Math.floor(Math.random() * medical.length)];
-    const location = medicalLocationFlavor[Math.floor(Math.random() * medicalLocationFlavor.length)];
+    const location = medicalType[2][Math.floor(Math.random() * medicalType[2].length)];
     addEvent(`${who} found medical supplies (${medicalType[0]}) ${location}.`);
     addItemToInventory(medicalType);
     updateMedicalButtons();
@@ -56,7 +45,8 @@ export function foundMedical(who) {
 export function foundFood(who) {
     const foodType = food[Math.floor(Math.random() * food.length)];
     const variation = foodType[2][Math.floor(Math.random() * foodType[2].length)];
-    addEvent(`${who} found ${variation} (${foodType[0]}).`);
+    const location = foodType[3][Math.floor(Math.random() * foodType[3].length)];
+    addEvent(`${who} found ${variation} (${foodType[0]}) ${location}.`);
     addItemToInventory(foodType);
     updateFoodButtons();
 }

--- a/the-wanderers/scripts/src/events.js
+++ b/the-wanderers/scripts/src/events.js
@@ -254,7 +254,25 @@ export function getEvent(chance) {
                 index2 = Math.floor(Math.random() * context.gameParty.characters.length);
             } while (index2 === index1);
             const name2 = context.gameParty.characters[index2];
-            if (Math.random() < 0.5) {
+            
+            // Calculate interaction probability modifier based on traits
+            // Positive modifiers increase positive interaction chance
+            // friendly: +20%, optimistic: -20% negative (same as +20% positive)
+            // disconnected: +20% negative, depressed: -20% positive
+            let positiveModifier = 0;
+            
+            // Check both characters' traits
+            for (const char of [name1, name2]) {
+                if (char.posTrait === 'friendly') positiveModifier += 0.2;
+                if (char.posTrait === 'optimistic') positiveModifier += 0.2;
+                if (char.negTrait === 'disconnected') positiveModifier -= 0.2;
+                if (char.negTrait === 'depressed') positiveModifier -= 0.2;
+            }
+            
+            // Base 50% for negative, modified by traits (clamped to 10%-90%)
+            const negativeChance = Math.max(0.1, Math.min(0.9, 0.5 - positiveModifier));
+            
+            if (Math.random() < negativeChance) {
                 let hasFood = false;
                 for (const foodItem of food) {
                     if (context.gameParty.inventory.hasItem(foodItem[0])) {

--- a/the-wanderers/scripts/src/inventory.js
+++ b/the-wanderers/scripts/src/inventory.js
@@ -34,8 +34,12 @@ export function updateFoodAttributes(character, foodItem) {
     }
     if (foodItem[0] === 'dessert') {
         character.morale += 1;
-    } else if (character.negTrait === 'hungry' && (foodItem[0] === 'rations' || foodItem[0] === 'snack')) {
+    }
+    if (character.negTrait === 'hungry' && (foodItem[0] === 'rations' || foodItem[0] === 'snack')) {
         character.hunger -= foodItem[1];
+        addEvent(`That food didn't make ${character.name} feel much better.`);
+    } else {
+        addEvent(`${character.name} ate the ${foodItem[0]}.`);
     }
     updateFoodButtons();
 }

--- a/the-wanderers/scripts/src/survivor-encounters.js
+++ b/the-wanderers/scripts/src/survivor-encounters.js
@@ -1,0 +1,566 @@
+import { food, medical, weapons } from '../party.js';
+import { addEvent, updateStatBars, updateFoodButtons, updateMedicalButtons, setPlayButton, updateRelationships, handleGameOver } from './ui.js';
+import { addItemToInventory, updateWeaponButtons } from './inventory.js';
+import { context } from '../game-state.js';
+import { handleDeathEffects } from './events.js';
+import {
+    survivorAttackDescriptions,
+    hostileSurvivorAttackDescriptions,
+    merchantIntroductions,
+    personInNeedIntroductions,
+    hostileSurvivorIntroductions,
+    survivorFleeMessages,
+    survivorGiveUpMessages
+} from './constants.js';
+
+/**
+ * Get a random element from an array
+ * @param {Array} array - The array to pick from
+ * @returns {*} A random element from the array
+ */
+function getRandomElement(array) {
+    return array[Math.floor(Math.random() * array.length)];
+}
+
+/**
+ * Check if any enemies remain in combat
+ * @param {Array} combatants - All combatants in the fight
+ * @param {Array} players - The player combatants
+ * @returns {boolean} True if any enemies are still alive
+ */
+function hasEnemiesRemaining(combatants, players) {
+    return combatants.some(c => !players.some(p => p.type === c.type));
+}
+
+/**
+ * Get a random weapon, excluding fists (index 0)
+ * @returns {Array} A random weapon item
+ */
+function getRandomWeaponExcludingFists() {
+    return weapons[Math.floor(Math.random() * (weapons.length - 1)) + 1];
+}
+
+/**
+ * Main entry point for survivor encounters
+ * Called from events.js when a survivor encounter is triggered
+ */
+export function foundSurvivor() {
+    setPlayButton('hide');
+    
+    // Randomly choose encounter type: 40% merchant, 30% person in need, 30% hostile
+    const roll = Math.random();
+    if (roll < 0.4) {
+        merchantEncounter();
+    } else if (roll < 0.7) {
+        personInNeedEncounter();
+    } else {
+        hostileSurvivorEncounter();
+    }
+}
+
+/**
+ * Merchant encounter - offers trade
+ */
+function merchantEncounter() {
+    const intro = getRandomElement(merchantIntroductions);
+    addEvent(intro + '.');
+    
+    // Get a random item from a pool (food, medical, or weapon)
+    const merchantItem = getRandomMerchantItem();
+    
+    // Get a random item from party inventory
+    const partyItem = getRandomPartyItem();
+    
+    if (!partyItem) {
+        addEvent('They look at your empty packs and walk away disappointed.');
+        setPlayButton('show');
+        return;
+    }
+    
+    addEvent(`They offer to trade you a ${merchantItem[0]} for your ${partyItem.name}.`);
+    
+    const buttons = document.getElementById('gameButtons');
+    clearCombatButtons(buttons);
+    
+    // In test environment, buttons may be null
+    if (!buttons) {
+        setPlayButton('show');
+        return;
+    }
+    
+    // Accept button
+    const acceptButton = document.createElement('button');
+    acceptButton.textContent = 'Accept Trade';
+    acceptButton.addEventListener('click', () => {
+        // Remove party item from inventory
+        context.gameParty.inventory.removeItem(partyItem.name);
+        // Add merchant item to inventory
+        addItemToInventory(merchantItem);
+        addEvent(`You trade your ${partyItem.name} for the ${merchantItem[0]}.`);
+        
+        updateAllInventoryButtons();
+        context.gameParty.inventory.updateDisplay();
+        clearCombatButtons(buttons);
+        setPlayButton('show');
+    });
+    buttons.appendChild(acceptButton);
+    
+    // Decline button
+    const declineButton = document.createElement('button');
+    declineButton.textContent = 'Decline';
+    declineButton.addEventListener('click', () => {
+        addEvent('You politely decline. The survivor nods and walks away.');
+        clearCombatButtons(buttons);
+        setPlayButton('show');
+    });
+    buttons.appendChild(declineButton);
+    
+    // Steal button
+    const stealButton = document.createElement('button');
+    stealButton.textContent = 'Attempt to Steal';
+    stealButton.addEventListener('click', () => {
+        attemptSteal(merchantItem, buttons);
+    });
+    buttons.appendChild(stealButton);
+}
+
+/**
+ * Attempt to steal from merchant
+ * 50% hostile, 25% flee, 25% give up
+ */
+function attemptSteal(merchantItem, buttons) {
+    clearCombatButtons(buttons);
+    
+    const roll = Math.random();
+    if (roll < 0.25) {
+        // Survivor flees
+        const fleeMsg = getRandomElement(survivorFleeMessages);
+        addEvent(fleeMsg);
+        setPlayButton('show');
+    } else if (roll < 0.5) {
+        // Survivor gives up the item
+        const giveUpMsg = getRandomElement(survivorGiveUpMessages);
+        addEvent(giveUpMsg);
+        addItemToInventory(merchantItem);
+        updateAllInventoryButtons();
+        context.gameParty.inventory.updateDisplay();
+        setPlayButton('show');
+    } else {
+        // Survivor becomes hostile (50%)
+        addEvent('The survivor draws a weapon and attacks!');
+        startHostileSurvivorCombat(1);
+    }
+}
+
+/**
+ * Person in need encounter - asks for food or medical
+ */
+function personInNeedEncounter() {
+    const intro = getRandomElement(personInNeedIntroductions);
+    addEvent(intro + '.');
+    
+    // Randomly ask for food or medical
+    const wantsFood = Math.random() < 0.5;
+    const itemType = wantsFood ? 'food' : 'medical';
+    const itemPool = wantsFood ? food : medical;
+    
+    // Check if party has the item type
+    const hasItem = itemPool.some(item => context.gameParty.inventory.hasItem(item[0]));
+    
+    if (wantsFood) {
+        addEvent('They beg for something to eat.');
+    } else {
+        addEvent('They plead for medical supplies.');
+    }
+    
+    const buttons = document.getElementById('gameButtons');
+    clearCombatButtons(buttons);
+    
+    // In test environment, buttons may be null
+    if (!buttons) {
+        setPlayButton('show');
+        return;
+    }
+    
+    // Give button
+    const giveButton = document.createElement('button');
+    giveButton.textContent = hasItem ? `Give ${itemType}` : `No ${itemType} to give`;
+    giveButton.disabled = !hasItem;
+    giveButton.addEventListener('click', () => {
+        // Find first available item of the type
+        const itemToGive = itemPool.find(item => context.gameParty.inventory.hasItem(item[0]));
+        if (itemToGive) {
+            context.gameParty.inventory.removeItem(itemToGive[0]);
+            addEvent(`You give them the ${itemToGive[0]}. They thank you profusely.`);
+            
+            // Boost party morale
+            context.gameParty.characters.forEach(character => {
+                character.morale += 1;
+                character.capAttributes();
+                updateStatBars(character);
+            });
+            if (context.gameParty.characters.length === 1) {
+                addEvent(`${context.gameParty.characters[0].name} feels good about helping someone in need.`);
+            } else {
+                addEvent('The party feels good about helping someone in need.');
+            }
+            
+            updateAllInventoryButtons();
+            context.gameParty.inventory.updateDisplay();
+        }
+        clearCombatButtons(buttons);
+        setPlayButton('show');
+    });
+    buttons.appendChild(giveButton);
+    
+    // Decline button
+    const declineButton = document.createElement('button');
+    declineButton.textContent = 'Turn them away';
+    declineButton.addEventListener('click', () => {
+        clearCombatButtons(buttons);
+        
+        // 25% chance they become hostile
+        if (Math.random() < 0.25) {
+            addEvent('Desperation turns to rage. They attack!');
+            startHostileSurvivorCombat(1);
+        } else {
+            addEvent('They look disappointed and shuffle away.');
+            setPlayButton('show');
+        }
+    });
+    buttons.appendChild(declineButton);
+}
+
+/**
+ * Hostile survivor encounter - combat with no infection risk
+ */
+function hostileSurvivorEncounter() {
+    // Number of enemies scales with party size for balance
+    // Solo players always face 1 enemy, larger parties face 1-3
+    const numberOfEnemies = Math.min(3, Math.floor(Math.random() * context.gameParty.characters.length) + 1);
+    
+    // Use solo or group introductions based on party size
+    const isSolo = context.gameParty.characters.length === 1;
+    const introductions = isSolo ? hostileSurvivorIntroductions.solo : hostileSurvivorIntroductions.group;
+    const intro = getRandomElement(introductions);
+    addEvent(intro);
+    
+    if (numberOfEnemies > 1) {
+        addEvent(`${numberOfEnemies} hostile survivors surround you!`);
+    }
+    
+    startHostileSurvivorCombat(numberOfEnemies);
+}
+
+/**
+ * Start combat with hostile survivors
+ * Similar to zombie combat but no infection and different flavour
+ */
+function startHostileSurvivorCombat(numberOfEnemies) {
+    const buttons = document.getElementById('gameButtons');
+    clearCombatButtons(buttons);
+    
+    // Create survivors with 6-10 HP (tougher than zombies)
+    const enemies = [];
+    for (let i = 0; i < numberOfEnemies; i++) {
+        const hp = 6 + Math.floor(Math.random() * 5); // 6-10 HP
+        const morale = Math.floor(Math.random() * 10);
+        const attack = 1 + Math.floor(Math.random() * 2); // 1-2 damage
+        enemies.push({
+            type: 'survivor',
+            hp: hp,
+            morale: morale,
+            attack: attack
+        });
+    }
+    
+    const players = context.gameParty.characters
+        .map(character => ({
+            type: character.name,
+            hp: character.health,
+            morale: character.morale,
+            attack: weapons[character.weapon][1]
+        }));
+    
+    // Combine and sort by morale
+    const combatants = players.concat(enemies);
+    combatants.sort((a, b) => b.morale - a.morale);
+    
+    handleSurvivorTurn(0, combatants, players, setPlayButton);
+}
+
+/**
+ * Handle a turn in survivor combat
+ */
+function handleSurvivorTurn(index, combatants, players, setPlayButton) {
+    if (index >= combatants.length) {
+        index = 0;
+    }
+    
+    const current = combatants[index];
+    const isPlayer = players.some(p => p.type === current.type);
+    
+    if (current.hp <= 0) {
+        handleSurvivorTurn(index + 1, combatants, players, setPlayButton);
+        return;
+    }
+    
+    if (isPlayer) {
+        handlePlayerSurvivorTurn(current, combatants, players, setPlayButton, index);
+    } else {
+        handleEnemySurvivorTurn(current, combatants, players, setPlayButton, index);
+    }
+}
+
+/**
+ * Handle player's turn in survivor combat
+ */
+function handlePlayerSurvivorTurn(current, combatants, players, setPlayButton, index) {
+    const playerCharacter = context.gameParty.characters.find(c => c.name === current.type);
+    
+    if (!playerCharacter) {
+        handleSurvivorTurn(index + 1, combatants, players, setPlayButton);
+        return;
+    }
+    
+    setPlayButton('hide');
+    const buttons = document.getElementById('gameButtons');
+    clearCombatButtons(buttons);
+    
+    const validTargets = combatants.filter(c => !players.some(p => p.type === c.type) && c.hp > 0);
+    
+    validTargets.forEach((target, targetIndex) => {
+        const targetButton = document.createElement('button');
+        targetButton.textContent = `Attack survivor ${targetIndex + 1} (${target.hp} HP)`;
+        targetButton.addEventListener('click', () => {
+            // Get current weapon damage (in case weapon was changed mid-combat)
+            let damage = weapons[playerCharacter.weapon][1];
+            // Add fighter bonus
+            if (playerCharacter.posTrait === 'fighter') {
+                damage += 1;
+            }
+            const roll = Math.random();
+            
+            if (roll < 0.1) {
+                addEvent(`${current.type} misses the survivor!`);
+            } else if (playerCharacter.negTrait === 'clumsy' && roll < 0.2) {
+                playerCharacter.health -= 1;
+                addEvent(`${current.type} swings wildly and hurts themself!`);
+                updateStatBars(playerCharacter);
+                if (playerCharacter.health <= 0) {
+                    playerCharacter.health = 0;
+                    addEvent(`${playerCharacter.name} has been knocked out by their own clumsiness!`);
+                    handleDeathEffects(playerCharacter);
+                    context.gameParty.removeCharacter(playerCharacter);
+                }
+            } else {
+                if (roll > 0.9) {
+                    damage *= 2;
+                    addEvent(getRandomElement(survivorAttackDescriptions.critical)
+                        .replace('[attacker]', current.type));
+                } else {
+                    // Use weapon-specific attack descriptions
+                    const weaponName = weapons[playerCharacter.weapon][0];
+                    const weaponDescriptions = survivorAttackDescriptions[weaponName] || survivorAttackDescriptions.fist;
+                    addEvent(getRandomElement(weaponDescriptions)
+                        .replace('[attacker]', current.type));
+                }
+                target.hp -= damage;
+                
+                // Update weapon durability
+                if (playerCharacter.weapon > 0) {
+                    let durabilityLoss = 1;
+                    if (playerCharacter.posTrait === 'fighter' && Math.random() < 0.5) {
+                        durabilityLoss = 0;
+                    } else if (playerCharacter.negTrait === 'clumsy') {
+                        durabilityLoss = 2;
+                    }
+                    playerCharacter.weaponDurability -= durabilityLoss;
+                    if (playerCharacter.weaponDurability <= 0) {
+                        addEvent(`${playerCharacter.name}'s ${weapons[playerCharacter.weapon][0]} breaks!`);
+                        playerCharacter.weapon = 0;
+                        playerCharacter.weaponDurability = weapons[0][2];
+                        current.attack = weapons[0][1];
+                    }
+                    updateStatBars(playerCharacter);
+                    playerCharacter.updateCharacter();
+                }
+                
+                if (target.hp <= 0) {
+                    addEvent('The hostile survivor is defeated!');
+                    const targetIndex = combatants.indexOf(target);
+                    if (targetIndex > -1) {
+                        combatants.splice(targetIndex, 1);
+                    }
+                    
+                    if (!hasEnemiesRemaining(combatants, players)) {
+                        survivorCombatVictory(buttons, setPlayButton);
+                        return;
+                    }
+                }
+            }
+            
+            if (hasEnemiesRemaining(combatants, players)) {
+                clearCombatButtons(buttons);
+                handleSurvivorTurn(index + 1, combatants, players, setPlayButton);
+            }
+        });
+        buttons.appendChild(targetButton);
+    });
+}
+
+/**
+ * Handle enemy survivor's turn
+ */
+function handleEnemySurvivorTurn(combatant, combatants, players, setPlayButton, index) {
+    setPlayButton('hide');
+    const buttons = document.getElementById('gameButtons');
+    clearCombatButtons(buttons);
+    
+    const attackButton = document.createElement('button');
+    attackButton.textContent = 'The hostile survivor attacks!';
+    attackButton.id = 'attackButton';
+    attackButton.addEventListener('click', () => {
+        const validTargets = context.gameParty.characters.filter(c => c.health > 0);
+        if (validTargets.length === 0) {
+            survivorCombatDefeat(buttons);
+            return;
+        }
+        
+        const target = getRandomElement(validTargets);
+        const roll = Math.random();
+        
+        if (roll < 0.2) {
+            addEvent(`The survivor misses ${target.name}!`);
+        } else {
+            const attackDesc = getRandomElement(hostileSurvivorAttackDescriptions)
+                .replace('[NAME]', target.name);
+            addEvent(`The survivor ${attackDesc}!`);
+            target.health -= combatant.attack;
+            if (target.negTrait === 'vulnerable') {
+                target.health -= 1;
+            }
+            // No infection from survivor attacks
+            if (target.health <= 0) {
+                target.health = 0;
+                addEvent(`${target.name} has been killed!`);
+                handleDeathEffects(target);
+                context.gameParty.removeCharacter(target);
+                updateRelationships();
+            }
+            updateStatBars(target);
+        }
+        
+        // Check if all players are dead
+        if (!context.gameParty.characters.some(c => c.health > 0) || context.gameParty.characters.length === 0) {
+            survivorCombatDefeat(buttons);
+            return;
+        }
+        
+        // Check for victory
+        if (!hasEnemiesRemaining(combatants, players)) {
+            survivorCombatVictory(buttons, setPlayButton);
+            return;
+        }
+        
+        clearCombatButtons(buttons);
+        handleSurvivorTurn(index + 1, combatants, players, setPlayButton);
+    });
+    
+    buttons.appendChild(attackButton);
+}
+
+/**
+ * Handle survivor combat victory
+ */
+function survivorCombatVictory(buttons, setPlayButton) {
+    addEvent('All hostile survivors have been defeated!');
+    
+    // Chance to loot items from defeated survivors
+    if (Math.random() < 0.5) {
+        const lootRoll = Math.random();
+        if (lootRoll < 0.33) {
+            const foodItem = getRandomElement(food);
+            addEvent(`You find some ${foodItem[0]} on one of the survivors.`);
+            addItemToInventory(foodItem);
+            updateFoodButtons();
+        } else if (lootRoll < 0.67) {
+            const medItem = getRandomElement(medical);
+            addEvent(`You find a ${medItem[0]} on one of the survivors.`);
+            addItemToInventory(medItem);
+            updateMedicalButtons();
+        } else {
+            const weaponItem = getRandomWeaponExcludingFists();
+            addEvent(`You find a ${weaponItem[0]} on one of the survivors.`);
+            addItemToInventory(weaponItem);
+            updateWeaponButtons();
+        }
+    }
+    
+    // Morale boost for winning
+    context.gameParty.characters.forEach(character => {
+        if (character.health > 0) {
+            character.morale++;
+            character.capAttributes();
+            updateStatBars(character);
+        }
+    });
+    
+    context.gameParty.inventory.updateDisplay();
+    clearCombatButtons(buttons);
+    setPlayButton('show');
+}
+
+/**
+ * Handle survivor combat defeat
+ */
+function survivorCombatDefeat(buttons) {
+    addEvent('Game Over - The entire party has been defeated!');
+    handleGameOver(buttons);
+}
+
+/**
+ * Get a random item that a merchant might offer
+ */
+function getRandomMerchantItem() {
+    const roll = Math.random();
+    if (roll < 0.4) {
+        return getRandomElement(food);
+    } else if (roll < 0.7) {
+        return getRandomElement(medical);
+    } else {
+        return getRandomWeaponExcludingFists();
+    }
+}
+
+/**
+ * Get a random item from party inventory
+ */
+function getRandomPartyItem() {
+    const allItems = context.gameParty.inventory.getAllItems();
+    if (allItems.length === 0) {
+        return null;
+    }
+    return getRandomElement(allItems);
+}
+
+/**
+ * Helper to clear combat buttons
+ */
+function clearCombatButtons(buttons) {
+    if (!buttons) return;
+    Array.from(buttons.children).forEach(child => {
+        if (child.id !== 'playButton') {
+            child.remove();
+        }
+    });
+}
+
+/**
+ * Helper to update all inventory buttons
+ */
+function updateAllInventoryButtons() {
+    updateFoodButtons();
+    updateMedicalButtons();
+    updateWeaponButtons();
+}

--- a/the-wanderers/scripts/src/traits.js
+++ b/the-wanderers/scripts/src/traits.js
@@ -66,12 +66,6 @@ export function checkPosTraitEvents(character) {
             addEvent(`${character.name} is feeling a bit better.`);
         }
     }
-    if (character.posTrait === 'satiated') {
-        // every other turn, hunger goes down
-        if (context.turnNumber % 2 === 0) {
-            character.hunger += 0.5;
-        }
-    }
     if (character.posTrait === 'scavenger') {
         // 10% chance of finding an extra food item
         if (Math.random() < 0.1) {

--- a/the-wanderers/scripts/src/ui.js
+++ b/the-wanderers/scripts/src/ui.js
@@ -50,7 +50,6 @@ export function addEvent(eventText, style = "default") {
 
 export function updateButtons(type, items, buttonText, updateFunction) {
     if (!items) return; // Early return for interaction buttons which don't use items
-    if (items.length === 0) return;
 
     context.gameParty.characters.forEach(character => {
         const characterDiv = document.getElementById(character.name.split(' ').join(''));
@@ -75,6 +74,9 @@ export function updateButtons(type, items, buttonText, updateFunction) {
         while (select.options.length > 1) {
             select.remove(1);
         }
+
+        // If no items available, just leave the default option
+        if (items.length === 0) return;
 
         // Add options for each available item
         for (const item of items) {

--- a/the-wanderers/scripts/src/ui.js
+++ b/the-wanderers/scripts/src/ui.js
@@ -372,3 +372,26 @@ export function checkPartyAlerts(character) {
         }
     }
 }
+
+/**
+ * Handle game over state - clears UI and shows final message
+ * @param {HTMLElement} buttons - The game buttons container
+ */
+export function handleGameOver(buttons) {
+    if (buttons) {
+        Array.from(buttons.children).forEach(child => child.remove());
+    }
+    const playButton = document.getElementById('playButton');
+    if (playButton) {
+        playButton.remove();
+    }
+    const partyInventoryDiv = document.getElementById('partyInventory');
+    if (partyInventoryDiv) {
+        partyInventoryDiv.innerHTML = '';
+    }
+    const eventImage = document.getElementById('eventImage');
+    if (eventImage) {
+        eventImage.remove();
+    }
+    addEvent(`The adventure has come to an end. You survived for ${context.turnNumber} turns.`);
+}

--- a/the-wanderers/scripts/src/ui.js
+++ b/the-wanderers/scripts/src/ui.js
@@ -180,10 +180,24 @@ export function handleSelection(event, items, updateCharacterAttributes) {
                 }
             }
 
+            // Calculate interaction probability modifier based on traits
+            // friendly/optimistic: +10% positive each, disconnected/depressed: +10% negative each
+            let positiveModifier = 0;
+            for (const char of [character, target]) {
+                if (char.posTrait === 'friendly') positiveModifier += 0.1;
+                if (char.posTrait === 'optimistic') positiveModifier += 0.1;
+                if (char.negTrait === 'disconnected') positiveModifier -= 0.1;
+                if (char.negTrait === 'depressed') positiveModifier -= 0.1;
+            }
+            
             const chance = Math.random();
-            if (chance <= 0.5) {
+            // Adjust thresholds based on modifier (more positive = lower neutral threshold, higher positive threshold)
+            const neutralThreshold = Math.max(0.2, Math.min(0.7, 0.5 - positiveModifier));
+            const positiveThreshold = Math.max(0.5, Math.min(0.9, 0.75 + positiveModifier));
+            
+            if (chance <= neutralThreshold) {
                 addEvent(`${target.name} is not interested in talking right now.`);
-            } else if (chance <= 0.75) {
+            } else if (chance <= positiveThreshold) {
                 addEvent(`${target.name} is happy to chat.`);
                 if (character.relationships.get(target) < 4) {
                     character.relationships.set(target, character.relationships.get(target) + 1);
@@ -223,6 +237,22 @@ export function handleSelection(event, items, updateCharacterAttributes) {
                         // Pass durability for weapons, use correct update function
                         if (selectId === 'weaponSelect') {
                             updateWeaponAttributes(character, item, itemDurability);
+                        } else if (selectId === 'medicalSelect') {
+                            // Check if a hypochondriac steals the medical item
+                            const hypochondriacs = context.gameParty.characters.filter(
+                                c => c.negTrait === 'hypochondriac' && c !== character
+                            );
+                            if (hypochondriacs.length > 0 && Math.random() < 0.2) {
+                                // A random hypochondriac steals the item
+                                const thief = hypochondriacs[Math.floor(Math.random() * hypochondriacs.length)];
+                                addEvent(`${thief.name} panics and uses the ${item[0]} on themselves instead!`);
+                                updateCharacterAttributes(thief, item);
+                                thief.capAttributes();
+                                thief.updateCharacter();
+                                updateStatBars(thief);
+                            } else {
+                                updateCharacterAttributes(character, item);
+                            }
                         } else {
                             updateCharacterAttributes(character, item);
                         }


### PR DESCRIPTION
## Release Notes - Survivor Encounters

### New Features

**Survivor Encounters** - You now have a 20% chance of encountering other survivors instead of zombies when exploring. Three encounter types add variety and strategic choices:

- **Merchant (40%)** - A survivor offers to trade an item from their inventory for one of yours. You can accept the trade, decline politely, or attempt to steal — but beware, theft can turn them hostile.

- **Person in Need (30%)** - A desperate survivor asks for food or medical supplies. Helping them boosts party morale. Turning them away has a 25% chance of triggering a hostile response.

- **Hostile Survivor (30%)** - Bandits attack on sight. They're tougher than zombies (6-10 HP) but don't carry infection risk. Defeating them may reward you with loot.

### Improvements

- **Weapon-specific attack descriptions** - Combat text now varies based on equipped weapon (fist, stick, knife, pistol) with unique critical hit messages
- **Food consumption messages** - Characters now comment when eating, with special text when hungry
- **Solo player text variations** - Encounter messages adapt when playing with a single character

### Bug Fixes

- Fixed weapon durability not updating in the UI during combat
- Fixed birthday events triggering twice (day and night)
- Fixed weapon dropdowns not clearing when inventory becomes empty
- Fixed damage calculation using stale weapon data when switching weapons mid-combat

### Code Quality

- Extracted shared `handleGameOver()` utility for consistent game over handling
- Added helper functions for improved readability (`getRandomElement`, `hasEnemiesRemaining`, `getRandomWeaponExcludingFists`)

Closes #99 