### PR TITLE
End Game Statistics and Quick Equip/Use

### DIFF
--- a/the-wanderers/scripts/game.js
+++ b/the-wanderers/scripts/game.js
@@ -131,7 +131,8 @@ export function playTurn() {
                         character.updateCharacter(); // Update trait display (text and sprites)
                         updateStatBars(character);
                     }
-                }                if (character.morale <= 0 && context.gameParty.characters.length > 1) {
+                }               
+                if (character.morale <= 0 && context.gameParty.characters.length > 1) {
                     // Calculate average relationship level (0=cold to 4=family)
                     let totalRelationship = 0;
                     let otherCharacters = context.gameParty.characters.filter(c => c !== character);

--- a/the-wanderers/scripts/game.js
+++ b/the-wanderers/scripts/game.js
@@ -1,6 +1,6 @@
 import { context, advanceDay, getFormattedDate } from './game-state.js';
 import { food, medical } from './party.js';
-import { updateStatBars, addEvent, setPlayButton, updateRelationships, updateInteractionButtons, checkPartyAlerts, updateFoodButtons, updateMedicalButtons } from './src/ui.js';
+import { updateStatBars, addEvent, setPlayButton, updateRelationships, updateInteractionButtons, checkPartyAlerts, updateFoodButtons, updateMedicalButtons, handleGameOver } from './src/ui.js';
 import { createCharacterForm } from './src/character-creation.js';
 import { handleDeathEffects, getEvent } from './src/events.js';
 import { posTraits, negTraits } from './src/constants.js';
@@ -55,8 +55,9 @@ export function playTurn() {
         if (eventImage) {
             eventImage.remove();
         }
-        // output character is dead to the events div
-        addEvent('The adventure has come to an end. You survived for ' + context.turnNumber + ' turns.');
+        // Use handleGameOver to display end game message and statistics
+        const gameButtons = document.getElementById('gameButtons');
+        handleGameOver(gameButtons);
     } else {
         const chance = Math.random();
         const specialEventOccurred = getEvent(chance);
@@ -173,6 +174,17 @@ export function playTurn() {
                 if (character.posTrait === 'satiated') {
                     character.hunger = 0;
                     addEvent(`${character.name} is starving but manages to hold on.`);
+                    // Satiated has a cost - chance of morale or health loss
+                    if (Math.random() < 0.5) {
+                        character.morale -= 1;
+                        addEvent(`${character.name} is losing hope from the constant hunger.`);
+                    }
+                    if (Math.random() < 0.3) {
+                        character.health -= 1;
+                        addEvent(`${character.name}'s body is weakening from starvation.`);
+                    }
+                    character.capAttributes();
+                    updateStatBars(character);
                 } else {
                     addEvent(`${character.name} died of hunger.`);
                     handleDeathEffects(character);

--- a/the-wanderers/scripts/party.js
+++ b/the-wanderers/scripts/party.js
@@ -117,10 +117,20 @@ export class Inventory {
             existingItem.quantity += 1;
             this.inventoryMap.set(itemType[0], existingItem);
         } else {
+            // Determine the value to store
+            // For weapons: if full definition (3+ elements), use index 2 (durability)
+            // If abbreviated (2 elements like [name, durability]), use index 1
+            // For food/medical, use index 1 (effectiveness)
+            let valueToStore = itemType[1];
+            const isWeapon = weapons.some(w => w[0] === itemType[0]);
+            if (isWeapon && itemType.length >= 3) {
+                valueToStore = itemType[2]; // Use max durability from weapon definition
+            }
+            
             // If it does not exist, add it to the map
             this.inventoryMap.set(itemType[0], {
                 name: itemType[0],
-                value: itemType[1],
+                value: valueToStore,
                 quantity: 1
             });
         }

--- a/the-wanderers/scripts/party.js
+++ b/the-wanderers/scripts/party.js
@@ -1,3 +1,8 @@
+import { context } from './game-state.js';
+import { updateFoodAttributes, updateMedicalAttributes, updateWeaponAttributes } from './src/inventory.js';
+import { hungerArray, healthArray } from './character.js';
+import { updateStatBars } from './src/ui.js';
+
 // Item category definitions
 export const food = [
     ['rations', 0.5, [
@@ -156,9 +161,9 @@ export class Inventory {
         
         // Create categories
         const categories = {
-            food: { title: '🍗 Food', items: [], icon: '🍽️' },
-            medical: { title: '🩹 Medical', items: [], icon: '💊' },
-            weapons: { title: '⚔️ Weapons', items: [], icon: '🗡️' }
+            food: { title: '🍗 Food', items: [], icon: '🍽️', type: 'food' },
+            medical: { title: '🩹 Medical', items: [], icon: '💊', type: 'medical' },
+            weapons: { title: '⚔️ Weapons', items: [], icon: '🗡️', type: 'weapon' }
         };
         
         // Categorize items
@@ -175,6 +180,16 @@ export class Inventory {
             else if (weapons.some(weaponItem => weaponItem[0] === key)) {
                 categories.weapons.items.push(item);
             }
+        });
+        
+        // Sort items by effectiveness (highest value first)
+        categories.food.items.sort((a, b) => b.value - a.value);
+        categories.medical.items.sort((a, b) => b.value - a.value);
+        // Sort weapons by damage from weapons array (not stored value which may be durability)
+        categories.weapons.items.sort((a, b) => {
+            const aWeapon = weapons.find(w => w[0] === a.name);
+            const bWeapon = weapons.find(w => w[0] === b.name);
+            return (bWeapon ? bWeapon[1] : 0) - (aWeapon ? aWeapon[1] : 0);
         });
         
         // Create category container
@@ -216,6 +231,13 @@ export class Inventory {
                         <span class="item-quantity">x${item.quantity}</span>
                         <span class="item-value">${valueDisplay}</span>
                     `;
+                    
+                    // Add mini avatars for quick equip/use
+                    const miniAvatars = this.createMiniAvatars(item, category.type);
+                    if (miniAvatars) {
+                        itemElement.appendChild(miniAvatars);
+                    }
+                    
                     itemList.appendChild(itemElement);
                 });
                 
@@ -233,6 +255,140 @@ export class Inventory {
         }
         
         partyInventoryDiv.appendChild(inventoryContainer);
+    }
+
+    /**
+     * Create mini avatar buttons for quick equip/use
+     * @param {Object} item - The inventory item
+     * @param {string} type - 'food', 'medical', or 'weapon'
+     * @returns {HTMLElement|null} Container with mini avatars or null if none eligible
+     */
+    createMiniAvatars(item, type) {
+        if (!context.gameParty || !context.gameParty.characters || context.gameParty.characters.length === 0) {
+            return null;
+        }
+        
+        let eligibleCharacters = [];
+        
+        if (type === 'food') {
+            // Get characters who aren't full (hunger < max) and haven't used food action, sorted by lowest hunger first
+            const maxHunger = hungerArray.length - 1;
+            eligibleCharacters = context.gameParty.characters
+                .filter(c => c.hunger < maxHunger && (!c.actionsUsed || !c.actionsUsed.food))
+                .sort((a, b) => a.hunger - b.hunger); // Most hungry first
+        } else if (type === 'medical') {
+            // Get characters who aren't at full health and haven't used medical action, sorted by lowest health first
+            const maxHealth = healthArray.length - 1;
+            eligibleCharacters = context.gameParty.characters
+                .filter(c => c.health < maxHealth && (!c.actionsUsed || !c.actionsUsed.medical))
+                .sort((a, b) => a.health - b.health); // Most injured first
+        } else if (type === 'weapon') {
+            // Get characters whose current weapon is weaker than this one
+            const weaponInfo = weapons.find(w => w[0] === item.name);
+            if (weaponInfo) {
+                const itemDamage = weaponInfo[1];
+                eligibleCharacters = context.gameParty.characters
+                    .filter(c => weapons[c.weapon][1] < itemDamage)
+                    .sort((a, b) => weapons[a.weapon][1] - weapons[b.weapon][1]); // Weakest weapon first
+            }
+        }
+        
+        if (eligibleCharacters.length === 0) {
+            return null;
+        }
+        
+        const container = document.createElement('div');
+        container.className = 'mini-avatars';
+        
+        for (const character of eligibleCharacters) {
+            const avatarBtn = document.createElement('button');
+            avatarBtn.className = 'mini-avatar-btn';
+            avatarBtn.title = `Give ${item.name} to ${character.name}`;
+            
+            // Create mini avatar container for layered images
+            const avatarContainer = document.createElement('div');
+            avatarContainer.className = 'mini-avatar-layers';
+            
+            // Skin layer
+            const skinImg = document.createElement('img');
+            skinImg.src = character.skin;
+            skinImg.alt = '';
+            skinImg.className = 'mini-avatar-layer';
+            avatarContainer.appendChild(skinImg);
+            
+            // Hair layer
+            const hairImg = document.createElement('img');
+            hairImg.src = character.hair;
+            hairImg.alt = '';
+            hairImg.className = 'mini-avatar-layer';
+            avatarContainer.appendChild(hairImg);
+            
+            // Shirt layer
+            const shirtImg = document.createElement('img');
+            shirtImg.src = character.shirt;
+            shirtImg.alt = character.name;
+            shirtImg.className = 'mini-avatar-layer';
+            avatarContainer.appendChild(shirtImg);
+            
+            avatarBtn.appendChild(avatarContainer);
+            
+            // Add click handler
+            avatarBtn.addEventListener('click', () => {
+                this.quickUseItem(item, character, type);
+            });
+            
+            container.appendChild(avatarBtn);
+        }
+        
+        return container;
+    }
+
+    /**
+     * Quick use/equip an item on a character
+     * @param {Object} item - The inventory item
+     * @param {Object} character - The character to give the item to
+     * @param {string} type - 'food', 'medical', or 'weapon'
+     */
+    quickUseItem(item, character, type) {
+        // Find the full item data
+        let fullItem;
+        if (type === 'food') {
+            fullItem = food.find(f => f[0] === item.name);
+        } else if (type === 'medical') {
+            fullItem = medical.find(m => m[0] === item.name);
+        } else if (type === 'weapon') {
+            fullItem = weapons.find(w => w[0] === item.name);
+        }
+        
+        if (!fullItem) return;
+        
+        // Check if action has already been used (for food/medical)
+        if ((type === 'food' || type === 'medical') && character.actionsUsed?.[type]) {
+            return;
+        }
+        
+        // Remove from inventory
+        this.removeItem(item.name);
+        
+        // Apply the item effect and mark action as used
+        if (type === 'food') {
+            character.actionsUsed.food = true; // Set before update so dropdown gets disabled
+            updateFoodAttributes(character, fullItem);
+        } else if (type === 'medical') {
+            character.actionsUsed.medical = true; // Set before update so dropdown gets disabled
+            updateMedicalAttributes(character, fullItem);
+        } else if (type === 'weapon') {
+            // Get durability from the item before it was removed
+            const itemDurability = item.value;
+            updateWeaponAttributes(character, fullItem, itemDurability);
+        }
+        
+        character.capAttributes();
+        character.updateCharacter();
+        updateStatBars(character);
+        
+        // Refresh inventory display
+        this.updateDisplay();
     }
 }
 
@@ -272,7 +428,7 @@ class Party {
         const index = this.characters.indexOf(character);
         if (index !== -1) {
             this.characters.splice(index, 1);
-            const characterItem = document.getElementById(character.name);
+            const characterItem = document.getElementById(character.getCharacterId());
             if (characterItem) {
                 characterItem.remove();
             }

--- a/the-wanderers/scripts/src/age-effects.js
+++ b/the-wanderers/scripts/src/age-effects.js
@@ -1,8 +1,9 @@
 import { context } from '../game-state.js';
 import { food, medical, weapons } from '../party.js';
-import { addEvent, updateStatBars, updateFoodButtons, updateMedicalButtons } from './ui.js';
+import { addEvent, updateStatBars, updateFoodButtons, updateMedicalButtons, updateRelationships } from './ui.js';
 import { addItemToInventory, updateWeaponButtons } from './inventory.js';
 import { ageArray } from '../character.js';
+import { handleDeathEffects } from './events.js';
 
 // Age category constants
 export const AGE_TEEN = 0;    // 0-30 years
@@ -93,6 +94,12 @@ function applyElderEffects(character) {
                 addEvent(`${character.name}'s aging body is feeling fragile.`);
                 if (character.health <= 0) {
                     character.health = 0;
+                    addEvent(`${character.name}'s frail body gave out.`);
+                    handleDeathEffects(character);
+                    context.gameParty.removeCharacter(character);
+                    updateRelationships();
+                } else {
+                    updateStatBars(character);
                 }
             }
             break;
@@ -117,6 +124,12 @@ function applyElderEffects(character) {
                 addEvent(`${character.name}'s joints aren't what they used to be.`);
                 if (character.health <= 0) {
                     character.health = 0;
+                    addEvent(`${character.name} took a bad fall and didn't get back up.`);
+                    handleDeathEffects(character);
+                    context.gameParty.removeCharacter(character);
+                    updateRelationships();
+                } else {
+                    updateStatBars(character);
                 }
             }
             break;
@@ -163,7 +176,7 @@ export function checkBirthday(character) {
         addEvent(`${character.name} is now ${ageLabels[newAgeCategory]}!`);
         
         // Update age display in UI
-        const characterDiv = document.getElementById(character.name);
+        const characterDiv = document.getElementById(character.getCharacterId());
         if (characterDiv) {
             const ageElement = characterDiv.querySelector('.age');
             if (ageElement) {

--- a/the-wanderers/scripts/src/character-creation.js
+++ b/the-wanderers/scripts/src/character-creation.js
@@ -3,7 +3,7 @@ import { context, getFormattedDate } from '../game-state.js';
 import { posTraits, negTraits } from './constants.js';
 import Party, { food, medical, weapons } from '../party.js';
 import { setGameParty } from '../game-state.js';
-import { updateStatBars, addEvent, setPlayButton, updateFoodButtons, updateMedicalButtons, updateInteractionButtons } from './ui.js';
+import { updateStatBars, addEvent, setPlayButton, updateFoodButtons, updateMedicalButtons, updateInteractionButtons, updateRelationships } from './ui.js';
 import { playTurn } from '../game.js';
 import { newCharacterFlavour } from './events.js';
 import { addItemToInventory, updateWeaponButtons } from './inventory.js';
@@ -534,9 +534,9 @@ async function addPlayer() {
     try {
         // If we don't have any remaining names, fetch more
         if (!context.remainingNames || context.remainingNames.length === 0) {
-            context.remainingNames = await fetchNames(10);
-            if (context.remainingNames.length === 0) {
-                context.remainingNames = await fetchNames(10); // Try one more time if first attempt failed
+            await fetchNames(10);
+            if (!context.remainingNames || context.remainingNames.length === 0) {
+                await fetchNames(10); // Try one more time if first attempt failed
             }
         }
         
@@ -623,11 +623,12 @@ export function foundFriend() {
                 itemMessage = ` They brought a ${weaponType[0]} with them.`;
             }
             addEvent(`${newMember.name} has joined the party!${itemMessage}`);
-            // Update party inventory display
-            context.gameParty.inventory.updateDisplay();
         } else {
             addEvent(`${newMember.name} has joined the party!`);
         }
+        
+        // Update party inventory display to refresh mini avatars
+        context.gameParty.inventory.updateDisplay();
 
         // make morale of party members go up when a new member joins
         for (const character of context.gameParty.characters) {
@@ -643,6 +644,7 @@ export function foundFriend() {
         updateMedicalButtons();
         updateWeaponButtons();
         updateInteractionButtons();
+        updateRelationships();
 
         friendDiv.remove();
         acceptButton.remove();

--- a/the-wanderers/scripts/src/character-creation.js
+++ b/the-wanderers/scripts/src/character-creation.js
@@ -8,6 +8,7 @@ import { playTurn } from '../game.js';
 import { newCharacterFlavour } from './events.js';
 import { addItemToInventory, updateWeaponButtons } from './inventory.js';
 import { resetSeasonalEvents } from './seasonal-events.js';
+import { recordNewPartyMember, resetGameStats } from './game-stats.js';
 
 export async function fetchNames(amount = 10) {
     const spinner = document.createElement('div');
@@ -113,7 +114,10 @@ async function createForm() {
         // Initialize game state
         setGameParty(gameParty);
         resetSeasonalEvents(); // Reset seasonal event tracking for the new game
+        resetGameStats(); // Reset game statistics for new game
         gameParty.addCharacter(newCharacter);
+        // Track the first party member with their name and turn 1
+        recordNewPartyMember(name, 1);
         
         // Create character UI elements after clearing the form container
         const charactersDiv = document.getElementById('characters');
@@ -568,6 +572,8 @@ async function addPlayer() {
         // Create and add the character
         const newCharacter = new Character(firstName, age, posTrait, negTrait, skin, hair, shirt);
         context.gameParty.addCharacter(newCharacter);
+        // Track new party member with their name and current turn
+        recordNewPartyMember(firstName, context.turnNumber);
         
         // Create UI elements for the character
         newCharacter.createCharacter();

--- a/the-wanderers/scripts/src/combat.js
+++ b/the-wanderers/scripts/src/combat.js
@@ -4,6 +4,7 @@ import { context } from '../game-state.js';
 import { handleDeathEffects, singleZombieVariations, multiZombieVariations } from './events.js';
 import { attackDescriptions } from './constants.js';
 import { isHalloween, getHalloweenZombieDescription } from './seasonal-events.js';
+import { recordZombieKill, recordWeaponUse } from './game-stats.js';
 
 function handlePlayerTurn(current, combatants, players, context, setPlayButton, index) {
     const playerCharacter = context.gameParty.characters.find(c => c.name === current.type);
@@ -64,6 +65,8 @@ function handlePlayerTurn(current, combatants, players, context, setPlayButton, 
                     addEvent(weaponDescriptions[Math.floor(Math.random() * weaponDescriptions.length)]
                         .replace('[attacker]', current.type));
                 }
+                // Track weapon usage
+                recordWeaponUse(weapons[playerCharacter.weapon][0]);
                 target.hp -= damage;
                 
                 // Update weapon durability
@@ -89,6 +92,9 @@ function handlePlayerTurn(current, combatants, players, context, setPlayButton, 
                 
                 if (target.hp <= 0) {
                     addEvent('The zombie is defeated!');
+                    // Track the zombie kill with the weapon used
+                    const weaponName = weapons[playerCharacter.weapon][0];
+                    recordZombieKill(weaponName);
                     // Remove the dead enemy from combatants
                     const targetIndex = combatants.indexOf(target);
                     if (targetIndex > -1) {

--- a/the-wanderers/scripts/src/constants.js
+++ b/the-wanderers/scripts/src/constants.js
@@ -24,6 +24,15 @@ export const relationships = [
     'family'
 ];
 
+// Emoji placeholders for relationship levels (will be replaced with sprites later)
+export const relationshipEmojis = [
+    '❄️',  // cold
+    '👤',  // strangers
+    '🤝',  // acquaintances
+    '😊',  // friends
+    '❤️'   // family
+];
+
 export const attackDescriptions = {
     // Weapon-specific attack descriptions
     fist: [

--- a/the-wanderers/scripts/src/events.js
+++ b/the-wanderers/scripts/src/events.js
@@ -5,6 +5,7 @@ import { context } from '../game-state.js';
 import { foundEnemy } from './combat.js';
 import { foundFriend } from './character-creation.js';
 import { foundSurvivor } from './survivor-encounters.js';
+import { recordPartyMemberLeft } from './game-stats.js';
 
 export const singleZombieVariations = [
     'ambushes the camp from the bushes',
@@ -63,6 +64,9 @@ export function foundWeapon(who, id) {
 }
 
 export function handleDeathEffects(character) {
+    // Track this party member leaving
+    recordPartyMemberLeft(character.name, context.turnNumber);
+    
     // when a character dies check the relationships of the other characters and set morale accordingly
     /*
     Family -3

--- a/the-wanderers/scripts/src/game-stats.js
+++ b/the-wanderers/scripts/src/game-stats.js
@@ -1,0 +1,252 @@
+/**
+ * Game Statistics Tracking Module
+ * Tracks various statistics throughout the game for display at game over
+ */
+
+// Game statistics object
+const gameStats = {
+    // Combat stats
+    zombiesKilled: 0,
+    hostileSurvivorsKilled: 0,
+    
+    // Party stats
+    totalPartyMembers: 0,  // Total unique members who joined
+    
+    // Longest survivor tracking
+    partyMemberJoinTurns: new Map(), // Map of character name -> turn joined
+    longestSurvivor: { name: null, turns: 0 },
+    
+    // Item usage stats
+    foodEaten: 0,
+    medicalUsed: 0,
+    
+    // Weapon stats - track kills and usage per weapon type
+    weaponStats: {
+        fist: { kills: 0, uses: 0 },
+        stick: { kills: 0, uses: 0 },
+        knife: { kills: 0, uses: 0 },
+        pistol: { kills: 0, uses: 0 }
+    },
+    
+    // Survivor encounter stats
+    survivorEncounters: {
+        merchantTradesAccepted: 0,
+        merchantTradesDeclined: 0,
+        merchantStealAttempts: 0,
+        personInNeedHelped: 0,
+        personInNeedDeclined: 0,
+        hostileEncounters: 0
+    }
+};
+
+/**
+ * Record a zombie kill with the weapon used
+ * @param {string} weaponName - Name of the weapon used
+ */
+export function recordZombieKill(weaponName) {
+    gameStats.zombiesKilled++;
+    if (gameStats.weaponStats[weaponName]) {
+        gameStats.weaponStats[weaponName].kills++;
+    }
+}
+
+/**
+ * Record a weapon attack (for tracking usage)
+ * @param {string} weaponName - Name of the weapon used
+ */
+export function recordWeaponUse(weaponName) {
+    if (gameStats.weaponStats[weaponName]) {
+        gameStats.weaponStats[weaponName].uses++;
+    }
+}
+
+/**
+ * Record a hostile survivor kill
+ */
+export function recordHostileSurvivorKill() {
+    gameStats.hostileSurvivorsKilled++;
+}
+
+/**
+ * Record a new party member joining
+ * @param {string} characterName - Name of the character joining
+ * @param {number} currentTurn - The turn number when they joined
+ */
+export function recordNewPartyMember(characterName, currentTurn) {
+    gameStats.totalPartyMembers++;
+    gameStats.partyMemberJoinTurns.set(characterName, currentTurn);
+}
+
+/**
+ * Record food being eaten
+ */
+export function recordFoodEaten() {
+    gameStats.foodEaten++;
+}
+
+/**
+ * Record a party member leaving or dying
+ * @param {string} characterName - Name of the character leaving
+ * @param {number} currentTurn - The turn number when they left
+ */
+export function recordPartyMemberLeft(characterName, currentTurn) {
+    const joinTurn = gameStats.partyMemberJoinTurns.get(characterName);
+    if (joinTurn !== undefined) {
+        // +1 because if you join on turn 1 and leave on turn 10, you survived 10 turns
+        const turnsAlive = currentTurn - joinTurn + 1;
+        if (turnsAlive > gameStats.longestSurvivor.turns) {
+            gameStats.longestSurvivor = { name: characterName, turns: turnsAlive };
+        }
+        gameStats.partyMemberJoinTurns.delete(characterName);
+    }
+}
+
+/**
+ * Finalize longest survivor stats at game end (for survivors still alive)
+ * @param {Array} remainingCharacters - Array of character names still alive
+ * @param {number} finalTurn - The final turn number
+ */
+export function finalizeLongestSurvivor(remainingCharacters, finalTurn) {
+    for (const name of remainingCharacters) {
+        const joinTurn = gameStats.partyMemberJoinTurns.get(name);
+        if (joinTurn !== undefined) {
+            // +1 because if you join on turn 1 and game ends on turn 25, you survived 25 turns
+            const turnsAlive = finalTurn - joinTurn + 1;
+            if (turnsAlive > gameStats.longestSurvivor.turns) {
+                gameStats.longestSurvivor = { name: name, turns: turnsAlive };
+            }
+        }
+    }
+}
+
+/**
+ * Record medical item being used
+ */
+export function recordMedicalUsed() {
+    gameStats.medicalUsed++;
+}
+
+/**
+ * Record merchant trade accepted
+ */
+export function recordMerchantTradeAccepted() {
+    gameStats.survivorEncounters.merchantTradesAccepted++;
+}
+
+/**
+ * Record merchant trade declined
+ */
+export function recordMerchantTradeDeclined() {
+    gameStats.survivorEncounters.merchantTradesDeclined++;
+}
+
+/**
+ * Record merchant steal attempt
+ */
+export function recordMerchantStealAttempt() {
+    gameStats.survivorEncounters.merchantStealAttempts++;
+}
+
+/**
+ * Record helping a person in need
+ */
+export function recordPersonInNeedHelped() {
+    gameStats.survivorEncounters.personInNeedHelped++;
+}
+
+/**
+ * Record declining a person in need
+ */
+export function recordPersonInNeedDeclined() {
+    gameStats.survivorEncounters.personInNeedDeclined++;
+}
+
+/**
+ * Record a hostile survivor encounter
+ */
+export function recordHostileEncounter() {
+    gameStats.survivorEncounters.hostileEncounters++;
+}
+
+/**
+ * Get the favourite weapon based on kills, then uses as tiebreaker
+ * Excludes fist as it's the default fallback
+ * @returns {string} Name of the favourite weapon, or 'None' if only fists used
+ */
+export function getFavouriteWeapon() {
+    let maxKills = 0;
+    let maxUses = 0;
+    let favourite = null;
+    
+    // Only consider real weapons (not fist)
+    const realWeapons = ['stick', 'knife', 'pistol'];
+    
+    for (const weapon of realWeapons) {
+        const stats = gameStats.weaponStats[weapon];
+        if (stats.kills > maxKills || (stats.kills === maxKills && stats.uses > maxUses)) {
+            maxKills = stats.kills;
+            maxUses = stats.uses;
+            favourite = weapon;
+        }
+    }
+    
+    // If no kills with real weapons, pick by usage
+    if (favourite === null) {
+        maxUses = 0;
+        for (const weapon of realWeapons) {
+            const stats = gameStats.weaponStats[weapon];
+            if (stats.uses > maxUses) {
+                maxUses = stats.uses;
+                favourite = weapon;
+            }
+        }
+    }
+    
+    return favourite || 'None';
+}
+
+/**
+ * Get all game statistics for display
+ * @returns {Object} Copy of game statistics
+ */
+export function getGameStats() {
+    return {
+        zombiesKilled: gameStats.zombiesKilled,
+        hostileSurvivorsKilled: gameStats.hostileSurvivorsKilled,
+        totalPartyMembers: gameStats.totalPartyMembers,
+        longestSurvivor: { ...gameStats.longestSurvivor },
+        foodEaten: gameStats.foodEaten,
+        medicalUsed: gameStats.medicalUsed,
+        weaponStats: { ...gameStats.weaponStats },
+        survivorEncounters: { ...gameStats.survivorEncounters },
+        favouriteWeapon: getFavouriteWeapon()
+    };
+}
+
+/**
+ * Reset all statistics (for new game)
+ */
+export function resetGameStats() {
+    gameStats.zombiesKilled = 0;
+    gameStats.hostileSurvivorsKilled = 0;
+    gameStats.totalPartyMembers = 0;
+    gameStats.partyMemberJoinTurns = new Map();
+    gameStats.longestSurvivor = { name: null, turns: 0 };
+    gameStats.foodEaten = 0;
+    gameStats.medicalUsed = 0;
+    
+    for (const weapon of Object.keys(gameStats.weaponStats)) {
+        gameStats.weaponStats[weapon] = { kills: 0, uses: 0 };
+    }
+    
+    gameStats.survivorEncounters = {
+        merchantTradesAccepted: 0,
+        merchantTradesDeclined: 0,
+        merchantStealAttempts: 0,
+        personInNeedHelped: 0,
+        personInNeedDeclined: 0,
+        hostileEncounters: 0
+    };
+}
+
+export { gameStats };

--- a/the-wanderers/scripts/src/inventory.js
+++ b/the-wanderers/scripts/src/inventory.js
@@ -1,6 +1,7 @@
 import { addEvent, updateButtons, updateFoodButtons, updateMedicalButtons } from './ui.js';
 import { weapons } from '../party.js';
 import { context } from '../game-state.js';
+import { recordFoodEaten, recordMedicalUsed } from './game-stats.js';
 
 export function addItemToInventory(itemType) {
     // Use the new Inventory class's addItem method instead of directly manipulating inventoryMap
@@ -41,12 +42,16 @@ export function updateFoodAttributes(character, foodItem) {
     } else {
         addEvent(`${character.name} ate the ${foodItem[0]}.`);
     }
+    // Track food eaten
+    recordFoodEaten();
     updateFoodButtons();
 }
 
 export function updateMedicalAttributes(character, medicalItem) {
     character.health += medicalItem[1];
     addEvent(`${character.name} used the ${medicalItem[0]}.`);
+    // Track medical item used
+    recordMedicalUsed();
 
     handleInfectionCure(character, medicalItem);
     handleSicknessCure(character, medicalItem);

--- a/the-wanderers/scripts/src/ui.js
+++ b/the-wanderers/scripts/src/ui.js
@@ -599,7 +599,18 @@ function createStatsSection(title, statsList) {
     const list = document.createElement('ul');
     for (const stat of statsList) {
         const item = document.createElement('li');
-        item.innerHTML = `<span class="stat-label">${stat.label}:</span> <span class="stat-value">${stat.value}</span>`;
+        
+        const labelSpan = document.createElement('span');
+        labelSpan.className = 'stat-label';
+        labelSpan.textContent = `${stat.label}:`;
+        
+        const valueSpan = document.createElement('span');
+        valueSpan.className = 'stat-value';
+        valueSpan.textContent = stat.value;
+        
+        item.appendChild(labelSpan);
+        item.appendChild(document.createTextNode(' '));
+        item.appendChild(valueSpan);
         list.appendChild(item);
     }
     section.appendChild(list);

--- a/the-wanderers/styles/colour-theme_dark.css
+++ b/the-wanderers/styles/colour-theme_dark.css
@@ -68,8 +68,9 @@ form label {
     border: 2px solid #4b4b6b;
 }
 
-.name {
+.name-row {
     border: 2px solid #4b4b6b;
+    border-top: none;
 }
 
 #gameButtons {

--- a/the-wanderers/styles/colour-theme_green.css
+++ b/the-wanderers/styles/colour-theme_green.css
@@ -61,8 +61,9 @@ form label {
     border: 2px solid #23251b;
 }
 
-.name {
+.name-row {
     border: 2px solid #23251b;
+    border-top: none;
 }
 
 #gameButtons {

--- a/the-wanderers/styles/colour-theme_light.css
+++ b/the-wanderers/styles/colour-theme_light.css
@@ -61,8 +61,9 @@ form label {
     border: 2px solid #666666;
 }
 
-.name {
+.name-row {
     border: 2px solid #666666;
+    border-top: none;
 }
 
 #gameButtons {

--- a/the-wanderers/styles/main.css
+++ b/the-wanderers/styles/main.css
@@ -297,3 +297,68 @@ form input {
     color: #888;
     padding: 20px;
 }
+
+/* End Game Statistics Styles */
+.end-game-stats {
+    margin-top: 20px;
+    padding: 20px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.3) 100%);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    width: 100%;
+    max-width: 400px;
+}
+
+.end-game-stats h2 {
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 1.3em;
+    border-bottom: 2px solid;
+    padding-bottom: 10px;
+}
+
+.stats-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.stats-section {
+    padding: 15px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.stats-section h3 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 1.1em;
+    border-bottom: 1px solid;
+    padding-bottom: 8px;
+}
+
+.stats-section ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.stats-section li {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px dashed rgba(128, 128, 128, 0.3);
+}
+
+.stats-section li:last-child {
+    border-bottom: none;
+}
+
+.stat-label {
+    font-weight: normal;
+}
+
+.stat-value {
+    font-weight: bold;
+    color: #ffc107;
+}

--- a/the-wanderers/styles/main.css
+++ b/the-wanderers/styles/main.css
@@ -149,11 +149,28 @@ form input {
     image-rendering: pixelated;
 }
 
+.name-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: -2px 10px 10px 10px;
+    width: 416px;
+    gap: 10px;
+    padding: 5px 10px;
+    box-sizing: border-box;
+}
+
 .name {
-    margin: 0px 10px 10px 10px;
-    text-align: center;
-    width: 412px;
-    border-top: none;
+    margin: 0;
+    text-align: left;
+    flex-shrink: 0;
+    border: none !important;
+}
+
+.name-row .relationships {
+    flex: 1;
+    margin: 0;
+    width: auto;
 }
 
 #gameButtons {
@@ -161,9 +178,13 @@ form input {
     width: 50%;
 }
 
-#options, .relationships {
+#options {
     width: 400px;
     margin: 20px auto;
+}
+
+.relationships {
+    width: auto;
 }
 
 #options select{
@@ -261,6 +282,7 @@ form input {
 
 .inventory-item {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     padding: 5px 0;
     margin-bottom: 5px;
@@ -269,6 +291,11 @@ form input {
 
 .inventory-item:hover {
     background-color: rgba(255, 255, 255, 0.1);
+}
+
+.inventory-item .mini-avatars {
+    width: 100%;
+    margin-left: 28px;
 }
 
 .item-icon {
@@ -361,4 +388,100 @@ form input {
 .stat-value {
     font-weight: bold;
     color: #ffc107;
+}
+
+/* Mini Avatars for Quick Equip */
+.mini-avatars {
+    display: flex;
+    gap: 4px;
+    margin-top: 5px;
+    flex-wrap: wrap;
+}
+
+.mini-avatar-btn {
+    width: 36px;
+    height: 36px;
+    padding: 2px;
+    margin: 0;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+    overflow: hidden;
+    position: relative;
+}
+
+.mini-avatar-btn:hover {
+    border-color: #ffc107;
+    background: rgba(255, 193, 7, 0.2);
+}
+
+.mini-avatar-layers {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.mini-avatar-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    image-rendering: pixelated;
+    object-fit: cover;
+}
+
+.mini-avatar-img {
+    width: 100%;
+    height: 100%;
+    image-rendering: pixelated;
+    object-fit: cover;
+}
+
+/* Interaction Avatars for Relationships */
+.interaction-avatars {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.interaction-avatar-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+}
+
+.interaction-avatar-btn {
+    width: 32px;
+    height: 32px;
+    padding: 2px;
+    margin: 0;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+    overflow: hidden;
+    position: relative;
+}
+
+.interaction-avatar-btn:hover:not(:disabled) {
+    border-color: #4caf50;
+    background: rgba(76, 175, 80, 0.2);
+}
+
+.interaction-avatar-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.relationship-emoji {
+    font-size: 12px;
+    text-align: center;
+    line-height: 1;
 }


### PR DESCRIPTION
### New Features

- **End Game Statistics** (Closes #111): Comprehensive stats displayed at game over including turns survived, zombies killed, hostile survivors defeated, items found/used, merchant trades, and more
- **Quick Equip/Use** (Closes #113): Mini avatar buttons on inventory items let you quickly give food, medical supplies, or weapons to eligible party members without navigating dropdowns

### Bug Fixes

- **Weapon handoff to dying characters**: Fixed weapons being passed to characters who are also about to die from starvation, health loss, or morale loss in the same turn
- **Loot message for food**: Changed "You find some meal on one of the survivors" to "You find some food (meal) on one of the survivors"
- **New character spawn crash**: Fixed error when adding new party members after names list was exhausted - `fetchNames()` wasn't being called correctly
- **Flaky age test**: Fixed birthday calculation so character ages stay within expected category ranges regardless of current date

### Improvements

- **Consistent loot messages**: Medical supplies now display as "medical supplies (item)" to match food format
- **Code quality**: Simplified duplicate action validation using optional chaining
- **Code quality**: Extracted `isCharacterViable()` helper function for cleaner viability checks on characters